### PR TITLE
Use artifact-name in upload artifacts instead of name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,30 +15,35 @@ jobs:
             args: '--target aarch64-apple-darwin'
             targetPath: '/aarch64-apple-darwin'
             name: 'macOS 14 (ARM64)'
+            artifact-name: 'macos-14-arm64'
             rust-targets: 'aarch64-apple-darwin'
           - platform: 'macos-13'
             type: 'desktop'
             args: '--target x86_64-apple-darwin'
             targetPath: '/x86_64-apple-darwin'
             name: 'macOS 13 (AMD64)'
+            artifact-name: 'macos-13-amd64'
             rust-targets: 'x86_64-apple-darwin'
           - platform: 'ubuntu-22.04'
             type: 'desktop'
             args: ''
             targetPath: ''
             name: 'Ubuntu 22.04'
+            artifact-name: 'ubuntu-22.04'
             rust-targets: ''
           - platform: 'windows-2025'
             type: 'desktop'
             args: ''
             targetPath: ''
             name: 'Windows Server 2025'
+            artifact-name: 'winsrv-2025'
             rust-targets: ''
           - platform: 'ubuntu-22.04'
             type: 'android'
             args: ''
             targetPath: ''
             name: 'Android'
+            artifact-name: 'android'
             rust-targets: 'aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android'
 
     runs-on: ${{ matrix.platform }}
@@ -100,7 +105,7 @@ jobs:
         if: matrix.type == 'desktop'
         uses: actions/upload-artifact@v4
         with:
-          name: tauri-artifact-${{ matrix.platform }}
+          name: tauri-artifact-${{ matrix.artfact-name }}
           path: |
             ./src-tauri/target${{ matrix.targetPath }}/debug/bundle/dmg/*.dmg
             ./src-tauri/target${{ matrix.targetPath }}/debug/bundle/nsis/*.exe
@@ -178,7 +183,7 @@ jobs:
         if: matrix.type == 'Android'
         uses: actions/upload-artifact@v4
         with:
-          name: tauri-artifact-${{ matrix.platform }}
+          name: tauri-artifact-${{ matrix.artifact-name }}
           path: './src-tauri/gen/android/app/build/outputs'
           if-no-files-found: error
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
         if: matrix.type == 'desktop'
         uses: actions/upload-artifact@v4
         with:
-          name: tauri-artifact-${{ matrix.name }}
+          name: tauri-artifact-${{ matrix.platform }}
           path: |
             ./src-tauri/target${{ matrix.targetPath }}/debug/bundle/dmg/*.dmg
             ./src-tauri/target${{ matrix.targetPath }}/debug/bundle/nsis/*.exe
@@ -178,7 +178,7 @@ jobs:
         if: matrix.type == 'Android'
         uses: actions/upload-artifact@v4
         with:
-          name: tauri-artifact-${{ matrix.name }}
+          name: tauri-artifact-${{ matrix.platform }}
           path: './src-tauri/gen/android/app/build/outputs'
           if-no-files-found: error
 


### PR DESCRIPTION
Prevents this file naming issue from occurring:
![a](https://github.com/user-attachments/assets/accbf474-75ed-47e4-96df-4dec8650c93c)
