### PR TITLE
Introduce ARM64 support for linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,12 +40,6 @@ jobs:
             target-path: ''
             name: 'Windows Server 2025 (AMD64)'
             rust-targets: ''
-          - platform: 'windows-11-arm'
-            type: 'desktop'
-            args: ''
-            target-path: ''
-            name: 'Windows 11 (AArch64)'
-            rust-targets: ''
           - platform: 'ubuntu-22.04'
             type: 'android'
             args: ''
@@ -160,15 +154,6 @@ jobs:
         if: matrix.name == 'Windows Server 2025 (AMD64)'
         with:
           name: tauri-artifact-windows-2025-amd64
-          path: |
-            ./src-tauri/target${{ matrix.target-path }}/debug/bundle/nsis/*.exe
-          if-no-files-found: error
-
-      - name: 'Desktop: Upload artifacts (Windows)'
-        uses: actions/upload-artifact@v4
-        if: matrix.name == 'Windows 11 (AArch64)'
-        with:
-          name: tauri-artifact-windows-11-arm64
           path: |
             ./src-tauri/target${{ matrix.target-path }}/debug/bundle/nsis/*.exe
           if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,13 +86,13 @@ jobs:
         if: matrix.name == 'Ubuntu 22.04 (AMD64)'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf librust-atk-dev jq
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf librust-atk-dev jq xdg-utils
 
       - name: 'Ubuntu AArch64: Install linux dependencies'
         if: matrix.name == 'Ubuntu 22.04 (AArch64)'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf librust-atk-dev jq
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf librust-atk-dev jq xdg-utils
 
       - name: 'Shared: Install frontend dependencies'
         run: pnpm install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
             type: 'desktop'
             args: '--target aarch64-apple-darwin'
             target-path: '/aarch64-apple-darwin'
-            name: 'macOS 15 (ARM64)'
+            name: 'macOS 15 (AArch64)'
             rust-targets: 'aarch64-apple-darwin'
           - platform: 'macos-13'
             type: 'desktop'
@@ -26,13 +26,25 @@ jobs:
             type: 'desktop'
             args: ''
             target-path: ''
-            name: 'Ubuntu 22.04'
+            name: 'Ubuntu 22.04 (AMD64)'
+            rust-targets: ''
+          - platform: 'ubuntu-22.04-arm'
+            type: 'desktop'
+            args: ''
+            target-path: ''
+            name: 'Ubuntu 22.04 (AArch64)'
             rust-targets: ''
           - platform: 'windows-2025'
             type: 'desktop'
             args: ''
             target-path: ''
-            name: 'Windows Server 2025'
+            name: 'Windows Server 2025 (AMD64)'
+            rust-targets: ''
+          - platform: 'windows-11-arm'
+            type: 'desktop'
+            args: ''
+            target-path: ''
+            name: 'Windows 11 (AArch64)'
             rust-targets: ''
           - platform: 'ubuntu-22.04'
             type: 'android'
@@ -101,15 +113,25 @@ jobs:
         uses: actions/upload-artifact@v4
         if: matrix.name == 'Ubuntu 22.04'
         with:
-          name: tauri-artifact-ubuntu-2204
+          name: tauri-artifact-ubuntu-2204-amd64
           path: |
             ./src-tauri/target${{ matrix.target-path }}/debug/bundle/appimage/*.AppImage
             ./src-tauri/target${{ matrix.target-path }}/debug/bundle/deb/*.deb
           if-no-files-found: error
 
-      - name: 'Desktop: Upload artifacts (macOS ARM64)'
+      - name: 'Desktop: Upload artifacts (Ubuntu)'
         uses: actions/upload-artifact@v4
-        if: matrix.name == 'macOS 15 (ARM64)'
+        if: matrix.name == 'Ubuntu 22.04 (AArch64)'
+        with:
+          name: tauri-artifact-ubuntu-2204-arm64
+          path: |
+            ./src-tauri/target${{ matrix.target-path }}/debug/bundle/appimage/*.AppImage
+            ./src-tauri/target${{ matrix.target-path }}/debug/bundle/deb/*.deb
+          if-no-files-found: error
+
+      - name: 'Desktop: Upload artifacts (macOS AArch64)'
+        uses: actions/upload-artifact@v4
+        if: matrix.name == 'macOS 15 (AArch64)'
         with:
           name: tauri-artifact-macos-15-arm64
           path: |
@@ -129,9 +151,18 @@ jobs:
 
       - name: 'Desktop: Upload artifacts (Windows)'
         uses: actions/upload-artifact@v4
-        if: matrix.name == 'Windows Server 2025'
+        if: matrix.name == 'Windows Server 2025 (AMD64)'
         with:
-          name: tauri-artifact-windows-2025
+          name: tauri-artifact-windows-2025-amd64
+          path: |
+            ./src-tauri/target${{ matrix.target-path }}/debug/bundle/nsis/*.exe
+          if-no-files-found: error
+
+      - name: 'Desktop: Upload artifacts (Windows)'
+        uses: actions/upload-artifact@v4
+        if: matrix.name == 'Windows 11 (AArch64)'
+        with:
+          name: tauri-artifact-windows-11-arm64
           path: |
             ./src-tauri/target${{ matrix.target-path }}/debug/bundle/nsis/*.exe
           if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,8 +88,14 @@ jobs:
           cache-all-crates: true
           cache-targets: false
 
-      - name: 'Ubuntu: Install linux dependencies'
-        if: matrix.name == 'Ubuntu 22.04'
+      - name: 'Ubuntu AMD64: Install linux dependencies'
+        if: matrix.name == 'Ubuntu 22.04 (AMD64)'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf librust-atk-dev jq
+
+      - name: 'Ubuntu AArch64: Install linux dependencies'
+        if: matrix.name == 'Ubuntu 22.04 (AArch64)'
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf librust-atk-dev jq
@@ -111,7 +117,7 @@ jobs:
 
       - name: 'Desktop: Upload artifacts (Ubuntu)'
         uses: actions/upload-artifact@v4
-        if: matrix.name == 'Ubuntu 22.04'
+        if: matrix.name == 'Ubuntu 22.04 (AMD64)'
         with:
           name: tauri-artifact-ubuntu-2204-amd64
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
           includeRelease: false
           args: ${{ matrix.args }}
 
-      - name: 'Desktop: Upload artifacts (Ubuntu)'
+      - name: 'Desktop: Upload artifacts (Ubuntu AMD64)'
         uses: actions/upload-artifact@v4
         if: matrix.name == 'Ubuntu 22.04 (AMD64)'
         with:
@@ -119,7 +119,7 @@ jobs:
             ./src-tauri/target${{ matrix.target-path }}/debug/bundle/deb/*.deb
           if-no-files-found: error
 
-      - name: 'Desktop: Upload artifacts (Ubuntu)'
+      - name: 'Desktop: Upload artifacts (Ubuntu AArch64)'
         uses: actions/upload-artifact@v4
         if: matrix.name == 'Ubuntu 22.04 (AArch64)'
         with:
@@ -149,7 +149,7 @@ jobs:
             ./src-tauri/target${{ matrix.target-path }}/debug/bundle/macos/*.app
           if-no-files-found: error
 
-      - name: 'Desktop: Upload artifacts (Windows)'
+      - name: 'Desktop: Upload artifacts (Windows AMD64)'
         uses: actions/upload-artifact@v4
         if: matrix.name == 'Windows Server 2025 (AMD64)'
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,7 +123,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: matrix.name == 'Ubuntu 22.04 (AArch64)'
         with:
-          name: tauri-artifact-ubuntu-2204-arm64
+          name: tauri-artifact-ubuntu-2204-aarch64
           path: |
             ./src-tauri/target${{ matrix.target-path }}/debug/bundle/appimage/*.AppImage
             ./src-tauri/target${{ matrix.target-path }}/debug/bundle/deb/*.deb
@@ -133,7 +133,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: matrix.name == 'macOS 15 (AArch64)'
         with:
-          name: tauri-artifact-macos-15-arm64
+          name: tauri-artifact-macos-15-aarch64
           path: |
             ./src-tauri/target${{ matrix.target-path }}/debug/bundle/dmg/*.dmg
             ./src-tauri/target${{ matrix.target-path }}/debug/bundle/macos/*.app

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           - platform: 'macos-15'
             args: '--target aarch64-apple-darwin'
             target-path: '/aarch64-apple-darwin'
-            name: 'macOS 15 (AARCH64)'
+            name: 'macOS 15 (AArch64)'
             rust-targets: 'aarch64-apple-darwin'
             type: 'macos-aarch64'
           - platform: 'macos-13'
@@ -74,15 +74,27 @@ jobs:
           - platform: 'ubuntu-22.04'
             args: ''
             target-path: ''
-            name: 'Ubuntu 22.04'
+            name: 'Ubuntu 22.04 (AMD64)'
             rust-targets: ''
-            type: 'linux'
+            type: 'linux-amd64'
+          - platform: 'ubuntu-22.04-arm'
+            args: ''
+            target-path: ''
+            name: 'Ubuntu 22.04 (AArch64)'
+            rust-targets: ''
+            type: 'linux-aarch64'
           - platform: 'windows-2025'
             args: ''
             target-path: ''
-            name: 'Windows Server 2025'
+            name: 'Windows Server 2025 (AMD64)'
             rust-targets: ''
-            type: 'windows'
+            type: 'windows-amd64'
+          - platform: 'windows-11-arm'
+            args: ''
+            target-path: ''
+            name: 'Windows 11 (AArch64)'
+            rust-targets: ''
+            type: 'windows-aarch64'
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -144,8 +156,16 @@ jobs:
         run: |
           mkdir artifact-output
 
-      - name: 'Desktop: Put linux files in artifact-output'
-        if: matrix.type == 'linux'
+      - name: 'Desktop: Put linux amd64 files in artifact-output'
+        if: matrix.type == 'linux-amd64'
+        shell: bash
+        run: |
+          mv ./src-tauri/target${{ matrix.target-path }}/release/bundle/appimage/*.AppImage ./artifact-output/
+          mv ./src-tauri/target${{ matrix.target-path }}/release/bundle/appimage/*.AppImage.sig ./artifact-output/
+          mv ./src-tauri/target${{ matrix.target-path }}/release/bundle/deb/*.deb ./artifact-output/
+
+      - name: 'Desktop: Put linux AArch64 files in artifact-output'
+        if: matrix.type == 'linux-aarch64'
         shell: bash
         run: |
           mv ./src-tauri/target${{ matrix.target-path }}/release/bundle/appimage/*.AppImage ./artifact-output/
@@ -176,9 +196,9 @@ jobs:
           mv "$appZipFile" "./artifact-output/${appZipFileBasename%.app.tar.gz}_aarch64.app.tar.gz"
           mv "$appZipSigFile" "./artifact-output/${appZipSigFileBasename%.app.tar.gz.sig}_aarch64.app.tar.gz.sig"
 
-      - name: 'Windows: Upload unsigned artifact'
+      - name: 'Windows AMD64: Upload unsigned artifact'
         id: upload-unsigned-artifact
-        if: matrix.type == 'windows'
+        if: matrix.type == 'windows-amd64'
         uses: actions/upload-artifact@v4
         with:
           name: windows-unsigned
@@ -186,15 +206,32 @@ jobs:
             ./src-tauri/target${{ matrix.target-path }}/release/bundle/nsis/*.exe
           if-no-files-found: error
 
-      - name: 'Windows: Notify Admin'
-        if: matrix.type == 'windows'
+      - name: 'Windows AArch64: Upload unsigned artifact'
+        id: upload-unsigned-artifact
+        if: matrix.type == 'windows-AArch64'
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-unsigned
+          path: |
+            ./src-tauri/target${{ matrix.target-path }}/release/bundle/nsis/*.exe
+          if-no-files-found: error
+
+      - name: 'Windows AMD64: Notify Admin'
+        if: matrix.type == 'windows-amd64'
         uses: tsickert/discord-webhook@v7.0.0
         with:
           webhook-url: ${{ secrets.ADMIN_WEBHOOK_URL }}
           content: <@864603174899941376> Permit the signing request for SoulFireClient ${{ inputs.app-version }} https://app.signpath.io/Web/e091b552-3623-4d9d-83d7-059d8f32978b/SigningRequests
 
-      - name: 'Windows: Submit signing request'
-        if: matrix.type == 'windows'
+      - name: 'Windows AArch64: Notify Admin'
+        if: matrix.type == 'windows-aarch64'
+        uses: tsickert/discord-webhook@v7.0.0
+        with:
+          webhook-url: ${{ secrets.ADMIN_WEBHOOK_URL }}
+          content: <@864603174899941376> Permit the signing request for SoulFireClient ${{ inputs.app-version }} https://app.signpath.io/Web/e091b552-3623-4d9d-83d7-059d8f32978b/SigningRequests
+
+      - name: 'Windows AMD64: Submit signing request'
+        if: matrix.type == 'windows-amd64'
         uses: signpath/github-action-submit-signing-request@v1.1
         with:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
@@ -205,8 +242,27 @@ jobs:
           wait-for-completion: true
           output-artifact-directory: '/artifact-output'
 
-      - name: 'Windows: Prepare signed artifact'
+      - name: 'Windows AArch64: Submit signing request'
+        if: matrix.type == 'windows-aarch64'
+        uses: signpath/github-action-submit-signing-request@v1.1
+        with:
+          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+          organization-id: 'e091b552-3623-4d9d-83d7-059d8f32978b'
+          project-slug: 'SoulFireClient'
+          signing-policy-slug: 'release-signing'
+          github-artifact-id: '${{ steps.upload-unsigned-artifact.outputs.artifact-id }}'
+          wait-for-completion: true
+          output-artifact-directory: '/artifact-output'
+
+      - name: 'Windows AMD64: Prepare signed artifact'
         if: matrix.platform == 'windows-2025'
+        shell: bash
+        run: |
+          fileName=$(ls artifact-output/*.exe)
+          pnpm tauri signer sign -k "${{ secrets.TAURI_PRIVATE_KEY }}" -p "${{ secrets.TAURI_KEY_PASSWORD }}" $fileName
+
+      - name: 'Windows AArch64: Prepare signed artifact'
+        if: matrix.platform == 'windows-11-arm'
         shell: bash
         run: |
           fileName=$(ls artifact-output/*.exe)
@@ -232,8 +288,13 @@ jobs:
       - name: Download linux artifacts
         uses: actions/download-artifact@v4
         with:
-          name: linux
-          path: release-artifacts/linux
+          name: linux-amd64
+          path: release-artifacts/linux-amd64
+      - name: Download linux artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-aarch64
+          path: release-artifacts/linux-aarch64
       - name: Download macos-aarch64 artifacts
         uses: actions/download-artifact@v4
         with:
@@ -247,19 +308,28 @@ jobs:
       - name: Download windows artifacts
         uses: actions/download-artifact@v4
         with:
-          name: windows
+          name: windows-amd64
           path: release-artifacts/windows
+      - name: Download windows artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-aarch64
+          path: release-artifacts/windows-aarch64
       - name: Create latest.json
         id: create-latest-json
         run: |
-          linuxAppImageFile=$(ls release-artifacts/linux/*.AppImage)
-          linuxAppImageSigFile=$(ls release-artifacts/linux/*.AppImage.sig)
+          linuxAmd64AppImageFile=$(ls release-artifacts/linux/*.AppImage)
+          linuxAmd64AppImageSigFile=$(ls release-artifacts/linux/*.AppImage.sig)
+          linuxAarch64AppImageFile=$(ls release-artifacts/linux/*.AppImage)
+          linuxAarch64AppImageSigFile=$(ls release-artifacts/linux/*.AppImage.sig)
           macosAarch64File=$(ls release-artifacts/macos-aarch64/*.app.tar.gz)
           macosAarch64SigFile=$(ls release-artifacts/macos-aarch64/*.app.tar.gz.sig)
           macosAmd64File=$(ls release-artifacts/macos-amd64/*.app.tar.gz)
           macosAmd64SigFile=$(ls release-artifacts/macos-amd64/*.app.tar.gz.sig)
           windowsAmd64File=$(ls release-artifacts/windows/*.exe)
           windowsAmd64SigFile=$(ls release-artifacts/windows/*.exe.sig)
+          windowsAarch64File=$(ls release-artifacts/windows/*.exe)
+          windowsAarch64SigFile=$(ls release-artifacts/windows/*.exe.sig)
           currentDate=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")
           cat << EOF > 'release-artifacts/latest.json'
           {
@@ -269,6 +339,10 @@ jobs:
             "platforms": {
               "windows-x86_64": {
                 "signature": "$(cat "$windowsAmd64SigFile")",
+                "url": "https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${{ inputs.app-version }}/$(basename "$windowsAmd64File")"
+              },
+              "windows-aarch64": {
+                "signature": "$(cat "$windowsAarch64SigFile")",
                 "url": "https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${{ inputs.app-version }}/$(basename "$windowsAmd64File")"
               },
               "darwin-aarch64": {
@@ -282,6 +356,10 @@ jobs:
               "linux-x86_64": {
                 "signature": "$(cat "$linuxAppImageSigFile")",
                 "url": "https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${{ inputs.app-version }}/$(basename "$linuxAppImageFile")"
+              },
+              "linux-aarch64": {
+                "signature": "$(cat "$linuxAppImageSigFile")",
+                "url": "https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${{ inputs.app-version }}/$(basename "$linuxAppImageFile")"
               }
             }
           }
@@ -289,6 +367,7 @@ jobs:
           echo "macosAarch64File=$(basename "$macosAarch64File")" >> $GITHUB_OUTPUT
           echo "macosAmd64File=$(basename "$macosAmd64File")" >> $GITHUB_OUTPUT
           echo "windowsAmd64File=$(basename "$windowsAmd64File")" >> $GITHUB_OUTPUT
+          echo "windowsAarch64File=$(basename "$windowsAarch64File")" >> $GITHUB_OUTPUT
 
       - name: Build Changelog
         id: github_release
@@ -358,9 +437,11 @@ jobs:
             | Platform              | Download Link |
             |-----------------------|---------------|
             | Windows (x86_64)      | [Download](https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${{ inputs.app-version }}/${{ steps.create-latest-json.outputs.windowsAmd64File }}) |
+            | Windows (AArch64)      | [Download](https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${{ inputs.app-version }}/${{ steps.create-latest-json.outputs.windowsAmd64File }}) |
             | macOS (Intel)         | [Download](https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${{ inputs.app-version }}/${{ steps.create-latest-json.outputs.macosAmd64File }}) |
             | macOS (Apple Silicon) | [Download](https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${{ inputs.app-version }}/${{ steps.create-latest-json.outputs.macosAarch64File }}) |
             | Linux (x86_64)        | [Download](https://flathub.org/apps/com.soulfiremc.soulfire) |
+            | Linux (AArch64)        | [Download](https://flathub.org/apps/com.soulfiremc.soulfire) |
 
             ${{ steps.github_release.outputs.changelog }}
           tag_name: ${{ inputs.app-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,11 +125,17 @@ jobs:
           cache-all-crates: true
           cache-targets: false
 
-      - name: 'Ubuntu: Install dependencies'
-        if: matrix.type == 'linux'
+      - name: 'Ubuntu AMD64: Install dependencies'
+        if: matrix.type == 'linux-amd64'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.0-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf jq
+          sudo apt-get install -y libwebkit2gtk-4.0-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf jq xdg-utils
+
+      - name: 'Ubuntu AArch64: Install dependencies'
+        if: matrix.type == 'linux-aarch64'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.0-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf jq xdg-utils
 
       - name: 'Shared: Install frontend dependencies'
         run: pnpm install
@@ -271,10 +277,10 @@ jobs:
       - name: Create latest.json
         id: create-latest-json
         run: |
-          linuxAmd64AppImageFile=$(ls release-artifacts/linux/*.AppImage)
-          linuxAmd64AppImageSigFile=$(ls release-artifacts/linux/*.AppImage.sig)
-          linuxAarch64AppImageFile=$(ls release-artifacts/linux/*.AppImage)
-          linuxAarch64AppImageSigFile=$(ls release-artifacts/linux/*.AppImage.sig)
+          linuxAmd64AppImageFile=$(ls release-artifacts/linux-amd64/*.AppImage)
+          linuxAmd64AppImageSigFile=$(ls release-artifacts/linux-amd64/*.AppImage.sig)
+          linuxAarch64AppImageFile=$(ls release-artifacts/linux-aarch64/*.AppImage)
+          linuxAarch64AppImageSigFile=$(ls release-artifacts/linux-aarch64/*.AppImage.sig)
           macosAarch64File=$(ls release-artifacts/macos-aarch64/*.app.tar.gz)
           macosAarch64SigFile=$(ls release-artifacts/macos-aarch64/*.app.tar.gz.sig)
           macosAmd64File=$(ls release-artifacts/macos-amd64/*.app.tar.gz)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,12 +301,12 @@ jobs:
                 "url": "https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${{ inputs.app-version }}/$(basename "$macosAmd64File")"
               },
               "linux-x86_64": {
-                "signature": "$(cat "$linuxAppImageSigFile")",
-                "url": "https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${{ inputs.app-version }}/$(basename "$linuxAppImageFile")"
+                "signature": "$(cat "$linuxAmd64AppImageSigFile")",
+                "url": "https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${{ inputs.app-version }}/$(basename "$linuxAmd64AppImageFile")"
               },
               "linux-aarch64": {
-                "signature": "$(cat "$linuxAppImageSigFile")",
-                "url": "https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${{ inputs.app-version }}/$(basename "$linuxAppImageFile")"
+                "signature": "$(cat "$linuxAarch64AppImageSigFile")",
+                "url": "https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${{ inputs.app-version }}/$(basename "$linuxAarch64AppImageFile")"
               }
             }
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
         run: |
           mkdir artifact-output
 
-      - name: 'Desktop: Put linux amd64 files in artifact-output'
+      - name: 'Desktop: Put linux AMD64 files in artifact-output'
         if: matrix.type == 'linux-amd64'
         shell: bash
         run: |
@@ -166,7 +166,7 @@ jobs:
           mv ./src-tauri/target${{ matrix.target-path }}/release/bundle/appimage/*.AppImage.sig ./artifact-output/
           mv ./src-tauri/target${{ matrix.target-path }}/release/bundle/deb/*.deb ./artifact-output/
 
-      - name: 'Desktop: Put macos amd64 files in artifact-output'
+      - name: 'Desktop: Put macOS AMD64 files in artifact-output'
         if: matrix.type == 'macos-amd64'
         shell: bash
         run: |
@@ -178,7 +178,7 @@ jobs:
           mv "$appZipFile" "./artifact-output/${appZipFileBasename%.app.tar.gz}_x64.app.tar.gz"
           mv "$appZipSigFile" "./artifact-output/${appZipSigFileBasename%.app.tar.gz.sig}_x64.app.tar.gz.sig"
 
-      - name: 'Desktop: Put macos aarch64 files in artifact-output'
+      - name: 'Desktop: Put macOS AArch64 files in artifact-output'
         if: matrix.type == 'macos-aarch64'
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,12 +89,6 @@ jobs:
             name: 'Windows Server 2025 (AMD64)'
             rust-targets: ''
             type: 'windows-amd64'
-          - platform: 'windows-11-arm'
-            args: ''
-            target-path: ''
-            name: 'Windows 11 (AArch64)'
-            rust-targets: ''
-            type: 'windows-aarch64'
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -206,25 +200,8 @@ jobs:
             ./src-tauri/target${{ matrix.target-path }}/release/bundle/nsis/*.exe
           if-no-files-found: error
 
-      - name: 'Windows AArch64: Upload unsigned artifact'
-        id: upload-unsigned-artifact
-        if: matrix.type == 'windows-AArch64'
-        uses: actions/upload-artifact@v4
-        with:
-          name: windows-unsigned
-          path: |
-            ./src-tauri/target${{ matrix.target-path }}/release/bundle/nsis/*.exe
-          if-no-files-found: error
-
       - name: 'Windows AMD64: Notify Admin'
         if: matrix.type == 'windows-amd64'
-        uses: tsickert/discord-webhook@v7.0.0
-        with:
-          webhook-url: ${{ secrets.ADMIN_WEBHOOK_URL }}
-          content: <@864603174899941376> Permit the signing request for SoulFireClient ${{ inputs.app-version }} https://app.signpath.io/Web/e091b552-3623-4d9d-83d7-059d8f32978b/SigningRequests
-
-      - name: 'Windows AArch64: Notify Admin'
-        if: matrix.type == 'windows-aarch64'
         uses: tsickert/discord-webhook@v7.0.0
         with:
           webhook-url: ${{ secrets.ADMIN_WEBHOOK_URL }}
@@ -242,27 +219,8 @@ jobs:
           wait-for-completion: true
           output-artifact-directory: '/artifact-output'
 
-      - name: 'Windows AArch64: Submit signing request'
-        if: matrix.type == 'windows-aarch64'
-        uses: signpath/github-action-submit-signing-request@v1.1
-        with:
-          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
-          organization-id: 'e091b552-3623-4d9d-83d7-059d8f32978b'
-          project-slug: 'SoulFireClient'
-          signing-policy-slug: 'release-signing'
-          github-artifact-id: '${{ steps.upload-unsigned-artifact.outputs.artifact-id }}'
-          wait-for-completion: true
-          output-artifact-directory: '/artifact-output'
-
       - name: 'Windows AMD64: Prepare signed artifact'
         if: matrix.platform == 'windows-2025'
-        shell: bash
-        run: |
-          fileName=$(ls artifact-output/*.exe)
-          pnpm tauri signer sign -k "${{ secrets.TAURI_PRIVATE_KEY }}" -p "${{ secrets.TAURI_KEY_PASSWORD }}" $fileName
-
-      - name: 'Windows AArch64: Prepare signed artifact'
-        if: matrix.platform == 'windows-11-arm'
         shell: bash
         run: |
           fileName=$(ls artifact-output/*.exe)
@@ -309,12 +267,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: windows-amd64
-          path: release-artifacts/windows
-      - name: Download windows artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: windows-aarch64
-          path: release-artifacts/windows-aarch64
+          path: release-artifacts/windows-amd64
       - name: Create latest.json
         id: create-latest-json
         run: |
@@ -328,8 +281,6 @@ jobs:
           macosAmd64SigFile=$(ls release-artifacts/macos-amd64/*.app.tar.gz.sig)
           windowsAmd64File=$(ls release-artifacts/windows/*.exe)
           windowsAmd64SigFile=$(ls release-artifacts/windows/*.exe.sig)
-          windowsAarch64File=$(ls release-artifacts/windows/*.exe)
-          windowsAarch64SigFile=$(ls release-artifacts/windows/*.exe.sig)
           currentDate=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")
           cat << EOF > 'release-artifacts/latest.json'
           {
@@ -339,10 +290,6 @@ jobs:
             "platforms": {
               "windows-x86_64": {
                 "signature": "$(cat "$windowsAmd64SigFile")",
-                "url": "https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${{ inputs.app-version }}/$(basename "$windowsAmd64File")"
-              },
-              "windows-aarch64": {
-                "signature": "$(cat "$windowsAarch64SigFile")",
                 "url": "https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${{ inputs.app-version }}/$(basename "$windowsAmd64File")"
               },
               "darwin-aarch64": {
@@ -367,7 +314,6 @@ jobs:
           echo "macosAarch64File=$(basename "$macosAarch64File")" >> $GITHUB_OUTPUT
           echo "macosAmd64File=$(basename "$macosAmd64File")" >> $GITHUB_OUTPUT
           echo "windowsAmd64File=$(basename "$windowsAmd64File")" >> $GITHUB_OUTPUT
-          echo "windowsAarch64File=$(basename "$windowsAarch64File")" >> $GITHUB_OUTPUT
 
       - name: Build Changelog
         id: github_release
@@ -437,7 +383,6 @@ jobs:
             | Platform              | Download Link |
             |-----------------------|---------------|
             | Windows (x86_64)      | [Download](https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${{ inputs.app-version }}/${{ steps.create-latest-json.outputs.windowsAmd64File }}) |
-            | Windows (AArch64)      | [Download](https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${{ inputs.app-version }}/${{ steps.create-latest-json.outputs.windowsAmd64File }}) |
             | macOS (Intel)         | [Download](https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${{ inputs.app-version }}/${{ steps.create-latest-json.outputs.macosAmd64File }}) |
             | macOS (Apple Silicon) | [Download](https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${{ inputs.app-version }}/${{ steps.create-latest-json.outputs.macosAarch64File }}) |
             | Linux (x86_64)        | [Download](https://flathub.org/apps/com.soulfiremc.soulfire) |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,8 +285,8 @@ jobs:
           macosAarch64SigFile=$(ls release-artifacts/macos-aarch64/*.app.tar.gz.sig)
           macosAmd64File=$(ls release-artifacts/macos-amd64/*.app.tar.gz)
           macosAmd64SigFile=$(ls release-artifacts/macos-amd64/*.app.tar.gz.sig)
-          windowsAmd64File=$(ls release-artifacts/windows/*.exe)
-          windowsAmd64SigFile=$(ls release-artifacts/windows/*.exe.sig)
+          windowsAmd64File=$(ls release-artifacts/windows-amd64/*.exe)
+          windowsAmd64SigFile=$(ls release-artifacts/windows-amd64/*.exe.sig)
           currentDate=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")
           cat << EOF > 'release-artifacts/latest.json'
           {

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -1,3 +1,3 @@
 {
-  "productName": "soufire"
+  "productName": "soulfire"
 }


### PR DESCRIPTION
This PR introduces ARM64 compilation support for Ubuntu 22.04 which allows the soulfire client to run on ARM64-based linux units, However while there is an Windows 11 for ARM64 image available - it is not compatible with the rust toolchain system which means it is currently impossible to ship it.