### PR TITLE
Improve CI security, Metadata changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,10 @@
-name: 'test'
+name: Build
 
 on:
   - push
+
+permissions:
+  contents: write
 
 jobs:
   test-tauri:
@@ -56,20 +59,21 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: 'Shared: Checkout repository'
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # 6.0.0
         with:
           persist-credentials: false
 
       - name: 'Shared: Set up nasm'
-        uses: ilammy/setup-nasm@v1
+        uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # 1.5.2
 
       - name: 'Shared: Setup node'
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # 6.0.0
         with:
           node-version: lts/*
+          check-latest: true
 
       - name: 'Shared: Install pnpm'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # 4.2.0
         with:
           version: latest
 
@@ -83,13 +87,13 @@ jobs:
           echo "$env:CARGO_HOME\bin" >> $env:GITHUB_PATH
 
       - name: 'Shared: Install Rust toolchain'
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@cf76244e99afbae1b55057e1d471a1513fe6295c # 1.70.0
         with:
           targets: ${{ matrix.rust-targets }}
 
       - name: 'Desktop: Cache dependencies'
         if: matrix.type != 'android'
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # 2.8.2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
           workspaces: src-tauri
@@ -114,7 +118,7 @@ jobs:
 
       - name: 'Desktop: Build Tauri project'
         if: matrix.type != 'android'
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@19b93bb55601e3e373a93cfb6eb4242e45f5af20 # 0.6.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
@@ -125,7 +129,7 @@ jobs:
           args: ${{ matrix.args }}
 
       - name: 'Desktop: Upload artifacts (Ubuntu AMD64)'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # 5.0.0
         if: matrix.type == 'linux-amd64'
         with:
           name: tauri-artifact-linux-amd64
@@ -135,7 +139,7 @@ jobs:
           if-no-files-found: error
 
       - name: 'Desktop: Upload artifacts (Ubuntu AArch64)'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # 5.0.0
         if: matrix.type == 'linux-aarch64'
         with:
           name: tauri-artifact-linux-aarch64
@@ -145,7 +149,7 @@ jobs:
           if-no-files-found: error
 
       - name: 'Desktop: Upload artifacts (macOS AArch64)'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # 5.0.0
         if: matrix.type == 'macos-aarch64'
         with:
           name: tauri-artifact-macos-aarch64
@@ -155,7 +159,7 @@ jobs:
           if-no-files-found: error
 
       - name: 'Desktop: Upload artifacts (macOS AMD64)'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # 5.0.0
         if: matrix.type == 'macos-amd64'
         with:
           name: tauri-artifact-macos-amd64
@@ -165,7 +169,7 @@ jobs:
           if-no-files-found: error
 
       - name: 'Desktop: Upload artifacts (Windows AMD64)'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # 5.0.0
         if: matrix.type == 'windows-amd64'
         with:
           name: tauri-artifact-windows-amd64
@@ -174,7 +178,7 @@ jobs:
           if-no-files-found: error
 
       - name: 'Desktop: Upload artifacts (Windows AArch64)'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # 5.0.0
         if: matrix.type == 'windows-aarch64'
         with:
           name: tauri-artifact-windows-aarch64
@@ -193,7 +197,7 @@ jobs:
 
       - name: 'Android: Set up JDK 21'
         if: matrix.type == 'android'
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # 5.0.0
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -201,12 +205,12 @@ jobs:
 
       - name: 'Android: Setup Android SDK'
         if: matrix.type == 'android'
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # 3.2.2
 
       - name: 'Android: Set up NDK'
         if: matrix.type == 'android'
         id: setup-ndk
-        uses: nttld/setup-ndk@v1
+        uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410 # 1.5.0
         with:
           ndk-version: r26d
           link-to-sdk: false
@@ -248,7 +252,7 @@ jobs:
 
       - name: 'Android: Upload artifacts'
         if: matrix.type == 'android'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # 5.0.0
         with:
           name: tauri-artifact-android
           path: './src-tauri/gen/android/app/build/outputs'

--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -1,20 +1,24 @@
-name: crowdin-sync
+name: Sync Crowdin
 on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   synchronize-with-crowdin:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # 6.0.0
         with:
           persist-credentials: false
       - name: Crowdin Sync
         id: crowdin-download
-        uses: crowdin/github-action@v2
+        uses: crowdin/github-action@08713f00a50548bfe39b37e8f44afb53e7a802d4 # 2.12.0
         with:
           config: crowdin.yml
           upload_sources: true
@@ -33,6 +37,7 @@ jobs:
 
       - name: Enable auto-merge for the PR
         if: steps.crowdin-download.outputs.pull_request_url
-        run: gh pr --repo $GITHUB_REPOSITORY merge ${{ steps.crowdin-download.outputs.pull_request_url }} --auto --merge
+        run: gh pr --repo $GITHUB_REPOSITORY merge ${STEPS_CROWDIN_DOWNLOAD_OUTPUTS_PULL_REQUEST_URL} --auto --merge
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          STEPS_CROWDIN_DOWNLOAD_OUTPUTS_PULL_REQUEST_URL: ${{ steps.crowdin-download.outputs.pull_request_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: 'publish'
+name: Release
 
 on:
   workflow_dispatch:
@@ -10,6 +10,8 @@ on:
         description: 'Server version to use for release'
         required: true
 
+# FIXME: Entire secret keys should not be inherited, Use specific set of secrets explicitly instead.
+# See this issue to learn more: https://github.com/zizmorcore/zizmor/issues/360
 jobs:
   set-server-version:
     uses: AlexProgrammerDE/SoulFireClient/.github/workflows/set-server-version.yml@main
@@ -34,18 +36,19 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # 6.0.0
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: 'Push to release branch'
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@77c5b412c50b723d2a4fbc6d71fb5723bcd439aa # 1.0.0
         with:
           branch: 'release'
 
       - name: 'Push to demo branch'
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@77c5b412c50b723d2a4fbc6d71fb5723bcd439aa # 1.0.0
         with:
           branch: 'demo'
 
@@ -99,21 +102,22 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: 'Shared: Checkout Repository'
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # 6.0.0
         with:
           ref: ${{ github.ref }}
           persist-credentials: false
 
       - name: 'Shared: Set up nasm'
-        uses: ilammy/setup-nasm@v1
+        uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # 1.5.2
 
       - name: 'Shared: Setup node'
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # 6.0.0
         with:
           node-version: lts/*
+          check-latest: true
 
       - name: 'Shared: Install pnpm'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # 4.2.0
         with:
           version: latest
 
@@ -127,12 +131,12 @@ jobs:
           echo "$env:CARGO_HOME\bin" >> $env:GITHUB_PATH
 
       - name: 'Shared: Install Rust toolchain'
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@cf76244e99afbae1b55057e1d471a1513fe6295c # 1.70.0
         with:
           targets: ${{ matrix.rust-targets }}
 
       - name: 'Desktop: Cache dependencies'
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # 2.8.2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
           workspaces: src-tauri
@@ -156,7 +160,7 @@ jobs:
         run: pnpm install
 
       - name: 'Desktop: Build tauri project'
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@19b93bb55601e3e373a93cfb6eb4242e45f5af20 # 0.6.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
@@ -214,7 +218,7 @@ jobs:
       - name: 'Windows AMD64/AArch64: Upload unsigned artifact'
         id: upload-unsigned-artifact
         if: matrix.type == 'windows-amd64' || matrix.type == 'windows-aarch64'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # 5.0.0
         with:
           name: ${{ matrix.type }}-unsigned
           path: |
@@ -223,14 +227,14 @@ jobs:
 
       - name: 'Windows AMD64/AArch64: Notify Admin'
         if: matrix.type == 'windows-amd64' || matrix.type == 'windows-aarch64'
-        uses: tsickert/discord-webhook@v7.0.0
+        uses: tsickert/discord-webhook@b217a69502f52803de774ded2b1ab7c282e99645 # 7.0.0
         with:
           webhook-url: ${{ secrets.ADMIN_WEBHOOK_URL }}
           content: <@864603174899941376> Permit the signing request for SoulFireClient ${{ inputs.app-version }} on ${{ matrix.type }} https://app.signpath.io/Web/e091b552-3623-4d9d-83d7-059d8f32978b/SigningRequests
 
       - name: 'Windows AMD64/AArch64: Submit signing request'
         if: matrix.type == 'windows-amd64' || matrix.type == 'windows-aarch64'
-        uses: signpath/github-action-submit-signing-request@v2.0
+        uses: signpath/github-action-submit-signing-request@3f9250c56651ff692d6729a2fbb0603a42d7d322 # 2.0
         with:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
           organization-id: 'e091b552-3623-4d9d-83d7-059d8f32978b'
@@ -248,7 +252,7 @@ jobs:
           pnpm tauri signer sign -k "${{ secrets.TAURI_PRIVATE_KEY }}" -p "${{ secrets.TAURI_KEY_PASSWORD }}" $fileName
 
       - name: 'Desktop: Upload artifacts'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # 5.0.0
         with:
           name: ${{ matrix.type }}
           path: |
@@ -265,32 +269,32 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Download linux-amd64 artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # 6.0.0
         with:
           name: linux-amd64
           path: release-artifacts/linux-amd64
       - name: Download linux-aarch64 artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # 6.0.0
         with:
           name: linux-aarch64
           path: release-artifacts/linux-aarch64
       - name: Download macos-aarch64 artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # 6.0.0
         with:
           name: macos-aarch64
           path: release-artifacts/macos-aarch64
       - name: Download macos-amd64 artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # 6.0.0
         with:
           name: macos-amd64
           path: release-artifacts/macos-amd64
       - name: Download windows-amd64 artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # 6.0.0
         with:
           name: windows-amd64
           path: release-artifacts/windows-amd64
       - name: Download windows-aarch64 artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # 6.0.0
         with:
           name: windows-aarch64
           path: release-artifacts/windows-aarch64
@@ -314,33 +318,33 @@ jobs:
           currentDate=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")
           cat << EOF > 'release-artifacts/latest.json'
           {
-            "version": "${{ inputs.app-version }}",
+            "version": "${INPUTS_APP_VERSION}",
             "notes": "See the assets to download this version and install.",
             "pub_date": "$currentDate",
             "platforms": {
               "windows-x86_64": {
                 "signature": "$(cat "$windowsAmd64SigFile")",
-                "url": "https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${{ inputs.app-version }}/$(basename "$windowsAmd64File")"
+                "url": "https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${INPUTS_APP_VERSION}/$(basename "$windowsAmd64File")"
               },
               "windows-aarch64": {
                 "signature": "$(cat "$windowsAarch64SigFile")",
-                "url": "https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${{ inputs.app-version }}/$(basename "$windowsAarch64File")"
+                "url": "https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${INPUTS_APP_VERSION}/$(basename "$windowsAarch64File")"
               },
               "darwin-aarch64": {
                 "signature": "$(cat "$macosAarch64SigFile")",
-                "url": "https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${{ inputs.app-version }}/$(basename "$macosAarch64File")"
+                "url": "https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${INPUTS_APP_VERSION}/$(basename "$macosAarch64File")"
               },
               "darwin-x86_64": {
                 "signature": "$(cat "$macosAmd64SigFile")",
-                "url": "https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${{ inputs.app-version }}/$(basename "$macosAmd64File")"
+                "url": "https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${INPUTS_APP_VERSION}/$(basename "$macosAmd64File")"
               },
               "linux-x86_64": {
                 "signature": "$(cat "$linuxAmd64AppImageSigFile")",
-                "url": "https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${{ inputs.app-version }}/$(basename "$linuxAmd64AppImageFile")"
+                "url": "https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${INPUTS_APP_VERSION}/$(basename "$linuxAmd64AppImageFile")"
               },
               "linux-aarch64": {
                 "signature": "$(cat "$linuxAarch64AppImageSigFile")",
-                "url": "https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${{ inputs.app-version }}/$(basename "$linuxAarch64AppImageFile")"
+                "url": "https://github.com/AlexProgrammerDE/SoulFireClient/releases/download/${INPUTS_APP_VERSION}/$(basename "$linuxAarch64AppImageFile")"
               }
             }
           }
@@ -349,10 +353,12 @@ jobs:
           echo "macosAmd64DmgFile=$(basename "$macosAmd64DmgFile")" >> $GITHUB_OUTPUT
           echo "windowsAmd64File=$(basename "$windowsAmd64File")" >> $GITHUB_OUTPUT
           echo "windowsAarch64File=$(basename "$windowsAarch64File")" >> $GITHUB_OUTPUT
+        env:
+          INPUTS_APP_VERSION: ${{ inputs.app-version }}
 
       - name: Build Changelog
         id: github_release
-        uses: mikepenz/release-changelog-builder-action@v6
+        uses: mikepenz/release-changelog-builder-action@439f79b5b5428107c7688c1d2b0e8bacc9b8792c # 6.0.1
         with:
           mode: COMMIT
           toTag: ${{ github.ref }}
@@ -426,7 +432,7 @@ jobs:
 
       - name: Create Release
         id: init-release
-        uses: softprops/action-gh-release@v2.4.2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # 2.5.0
         with:
           body: |
             ## Download Links
@@ -457,8 +463,8 @@ jobs:
             release-artifacts/**/*.dmg
             release-artifacts/latest.json
 
-      - name: Discord Webhook Action
-        uses: tsickert/discord-webhook@v7.0.0
+      - name: Announce new SoulFireClient release
+        uses: tsickert/discord-webhook@b217a69502f52803de774ded2b1ab7c282e99645 # 7.0.0
         with:
           webhook-url: ${{ secrets.WEBHOOK_URL }}
           content: <@&850705047938793503> New SoulFireClient version released!

--- a/.github/workflows/set-server-version.yml
+++ b/.github/workflows/set-server-version.yml
@@ -1,4 +1,4 @@
-name: set-server-version
+name: Set Server Version
 
 on:
   workflow_dispatch:
@@ -22,15 +22,18 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: 'Shared: Checkout repository'
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # 6.0.0
         with:
           ref: ${{ github.ref }}
+          persist-credentials: false
 
       - name: 'Set Server Version'
         run: |
-          echo "pub const SOULFIRE_VERSION: &str = \"${{ inputs.version }}\";" > src-tauri/src/sf_version_constant.rs
+          echo "pub const SOULFIRE_VERSION: &str = \"${INPUTS_VERSION}\";" > src-tauri/src/sf_version_constant.rs
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
 
       - name: 'Commit Version'
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@28e16e81777b558cc906c8750092100bbb34c5e3 # 7.0.0
         with:
           commit_message: 'chore: bump server version to ${{ inputs.version }}'

--- a/.github/workflows/set-version.yml
+++ b/.github/workflows/set-version.yml
@@ -1,4 +1,4 @@
-name: set-version
+name: Set Version
 
 on:
   workflow_dispatch:
@@ -22,25 +22,27 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: 'Shared: Checkout repository'
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # 6.0.0
         with:
           ref: ${{ github.ref }}
+          persist-credentials: false
 
       - name: 'Shared: Setup node'
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # 6.0.0
         with:
           node-version: lts/*
+          check-latest: true
 
       - name: 'Shared: Install pnpm'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # 4.2.0
         with:
           version: latest
 
       - name: 'Shared: Install Rust toolchain'
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@cf76244e99afbae1b55057e1d471a1513fe6295c # 1.70.0
 
       - name: 'Desktop: Cache dependencies'
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # 2.8.2
         with:
           prefix-key: set-version
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -51,24 +53,30 @@ jobs:
 
       - name: 'Set JS Version'
         run: |
-          pnpm version --no-git-tag-version --allow-same-version ${{ inputs.version }}
+          pnpm version --no-git-tag-version --allow-same-version ${INPUTS_VERSION}
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
 
       - name: 'Set Cargo Version'
         run: |
           cargo install cargo-edit
-          cargo set-version ${{ inputs.version }} --manifest-path src-tauri/Cargo.toml
+          cargo set-version ${INPUTS_VERSION} --manifest-path src-tauri/Cargo.toml
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
 
       - name: 'Add to metainfo'
         run: |
-          if ! grep -q "<release version=\"${{ inputs.version }}\"" com.soulfiremc.soulfire.metainfo.xml; then
+          if ! grep -q "<release version=\"${INPUTS_VERSION}\"" com.soulfiremc.soulfire.metainfo.xml; then
             sed -i "/<releases>/a\\
-              <release version=\"${{ inputs.version }}\" date=\"$(date +"%Y-%m-%d")\">\\
-                <url type=\"details\">https://github.com/AlexProgrammerDE/SoulFireClient/releases/tag/${{ inputs.version }}</url>\\
+              <release version=\"${INPUTS_VERSION}\" date=\"$(date +"%Y-%m-%d")\">\\
+                <url type=\"details\">https://github.com/AlexProgrammerDE/SoulFireClient/releases/tag/${INPUTS_VERSION}</url>\\
               </release>" com.soulfiremc.soulfire.metainfo.xml
-            echo "Added release ${{ inputs.version }} to metainfo file"
+            echo "Added release ${INPUTS_VERSION} to metainfo file"
           else
-            echo "Release version ${{ inputs.version }} already exists in metainfo file, skipping addition"
+            echo "Release version ${INPUTS_VERSION} already exists in metainfo file, skipping addition"
           fi
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
 
       - name: 'Bump android version code'
         run: |
@@ -76,6 +84,6 @@ jobs:
           mv tmp.json src-tauri/tauri.conf.json
 
       - name: 'Commit Version'
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@28e16e81777b558cc906c8750092100bbb34c5e3 # 7.0.0
         with:
           commit_message: 'chore(release): bump version to ${{ inputs.version }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,11 @@
-name: 'Build and Test'
+name: Test
 
 on:
   - push
   - pull_request
+
+permissions:
+  contents: read
 
 jobs:
   test:
@@ -11,21 +14,22 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # 6.0.0
         with:
           persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # 4.2.0
         name: Install pnpm
         with:
           version: latest
           run_install: false
 
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # 6.0.0
         with:
           node-version: lts/*
           cache: 'pnpm'
+          check-latest: true
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
1. Changes the CI's contents permission to read-only - However use `write` if a specific repository absolutely [requires it](https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-contents),
2. Pins all job versions to their commit hashes to avoid [supply chain attacks towards the workflow script](https://blog.rafaelgss.dev/why-you-should-pin-actions-by-commit-hash),
3. Moves all environment mentions into the `env:` section to prevent causing them from getting expanded into attacker-controllable code,
4. Adds `FIXME` comment for inherited secrets as i cannot resolve secret-related issues.

*(All security issues were spotted by the `zizmor` library)*

Also, not part of security but certain metadata sections have been changed to avoid making actions page confusing to navigate.